### PR TITLE
Incluit Smartcity Near-misses 2019

### DIFF
--- a/cpp/smart_city_near_misses/CMakeLists.txt
+++ b/cpp/smart_city_near_misses/CMakeLists.txt
@@ -69,5 +69,5 @@ COMPILE_PDB_NAME ${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} format_reader IE::ie_cpu_extension ${IE_LIBRARIES} ${InferenceEngine_LIBRARIES} gflags)
 
 if(UNIX)
-    target_link_libraries( ${TARGET_NAME} ${LIB_DL} pthread ${OpenCV_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries( ${TARGET_NAME} ${LIB_DL} pthread ${OpenCV_LIBRARIES} ${Boost_LIBRARIES} gomp)
 endif()

--- a/cpp/smart_city_near_misses/SmartCityDemo.ipynb
+++ b/cpp/smart_city_near_misses/SmartCityDemo.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "There are several source files in the `src/` directory: \n",
     "\n",
-    "We have provided a CMakeLists file for compiling the application. We will be compile the code remotly to take advantage of additional cores (note the `make -j`). Run the following cells to compile.\n",
+    "We have provided a CMakeLists file for compiling the application. Run the following cell to run the make command.\n",
     "It's important to source the setupenv.sh file as it defines some env variables that enable compiling the sample for different OpenVINO versions."
    ]
   },
@@ -72,7 +72,6 @@
     "mkdir build && cd build \n",
     "cmake ../\n",
     "make -j\n",
-    "#copying the executable to the base directory to make following cells easier\n",
     "cp intel64/Release/smart_city_tutorial ../"
    ]
   },
@@ -88,12 +87,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!qstat"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This produces an executable [smart_city_tutorial]().\n",
+    "This produces an executable [smart_city_tutorial]() in `build/intel64/Release/`. This executable takes in a number of different command line arguments. First, We copy it on the root directory to simplify the next commands.\n",
     "\n",
-    "Run the following cell to see the list of arguments: "
+    "Run the following cell to see the list: "
    ]
   },
   {

--- a/cpp/smart_city_near_misses/SmartCityDemo.ipynb
+++ b/cpp/smart_city_near_misses/SmartCityDemo.ipynb
@@ -61,18 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile compile.sh\n",
-    "#PBS\n",
-    "cd $PBS_O_WORKDIR\n",
-    "source scripts/setupenv.sh \n",
-    "export BOOST_LIBRARYDIR=/usr/lib/x86_64-linux-gnu/\n",
-    "if [[ -d build ]]; then\n",
-    "  rm -rf build\n",
-    "fi\n",
-    "mkdir build && cd build \n",
-    "cmake ../\n",
-    "make -j\n",
-    "cp intel64/Release/smart_city_tutorial ../"
+    "!mkdir build && cd build && . ../scripts/setupenv.sh && cmake .."
    ]
   },
   {
@@ -81,18 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "compile_job_id = !qsub -l nodes=1:tank-870:e3-1268l-v5\n",
-    "print(\"waiting for job {} to complete...\".format(compile_job_id[0]))\n",
-    "qjobWait([compile_job_id[0]])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!qstat"
+    "!cd build && . ../scripts/setupenv.sh && make"
    ]
   },
   {
@@ -102,6 +80,15 @@
     "This produces an executable [smart_city_tutorial]() in `build/intel64/Release/`. This executable takes in a number of different command line arguments. First, We copy it on the root directory to simplify the next commands.\n",
     "\n",
     "Run the following cell to see the list: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cp build/intel64/Release/smart_city_tutorial ."
    ]
   },
   {

--- a/cpp/smart_city_near_misses/SmartCityDemo.ipynb
+++ b/cpp/smart_city_near_misses/SmartCityDemo.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This produces an executable [smart_city_tutorial]() in `build/intel64/Release/`. This executable takes in a number of different command line arguments. First, We copy it on the root directory to simplify the next commands.\n",
+    "This produces an executable [smart_city_tutorial]() in `build/intel64/Release/`. This executable takes in a number of different command line arguments. First, we copy it on the root directory to simplify the next commands.\n",
     "\n",
     "Run the following cell to see the list: "
    ]
@@ -114,6 +114,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Downloading IR Model\n",
+    "\n",
+    "The Intel® Distribution of OpenVINO™ toolkit comes with model downloader that can download pre-compiled Intermediate Representation (IR) models that are optimized for different end-point target devices.\n",
+    "These models can be created from existing DNN models from popular frameworks (e.g. Caffe*, TF) using the Model Optimizer. \n",
+    "\n",
+    "Run the following cell to see the models available through `model_downloader.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!/opt/intel/openvino/deployment_tools/tools/model_downloader/downloader.py --print_all"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note** the '!' is a special Jupyter Notebook command that allows you to run shell commands as if you are in a command line. So the above command will work straight out of the box on in a terminal (with '!' removed).\n",
+    "\n",
+    "In this demo we will be using the 1 different types of models, with two model files for FP16 and FP32. These models can be downloaded with the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!/opt/intel/openvino/deployment_tools/tools/model_downloader/downloader.py --name person-vehicle-bike-detection-crossroad* -o models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The input arguments are as follows:\n",
+    "* --name : name of the model you want to download. It should be one of the models listed in the previous cell\n",
+    "* -o : output directory. If this directory does not exist, it will be created for you.\n",
+    "\n",
+    "There are more arguments to this script and you can get the full list using the `-h` option."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Running the inference\n",
     "\n",
     "Now we are ready to run the inference workload. In this step we will be submitting the workload as a job to the job queue.\n",
@@ -136,18 +186,21 @@
     "VIDEO_INPUT=$3\n",
     "OUTPUT_PATH=$4\n",
     "\n",
-    "if [ \"$1\" = \"HETERO:FPGA,CPU\" ]; then\n",
+    "if [ \"$DEVICE\" = \"HETERO:FPGA,CPU\" ]; then\n",
     "    # Environment variables and compilation for edge compute nodes with FPGAs\n",
-    "    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/altera/aocl-pro-rte/aclrte-linux64/\n",
     "    source /opt/fpga_support_files/setup_env.sh\n",
-    "    aocl program acl0 /opt/intel/computer_vision_sdk/bitstreams/a10_vision_design_bitstreams/5-0_PL1_FP11_ResNet.aocx\n",
+    "    aocl program acl0 /opt/intel/openvino/bitstreams/a10_vision_design_bitstreams/2019R1_PL1_FP11_MobileNet_Clamp.aocx\n",
+    "fi\n",
+    "\n",
+    "if [ \"$FP_MODEL\" = \"FP16\" ]; then\n",
+    "  FPEXT='-fp16'\n",
     "fi\n",
     "\n",
     "cd $PBS_O_WORKDIR\n",
-    "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/computer_vision_sdk/deployment_tools/inference_engine/samples/build/intel64/Release/lib/ \n",
-    "MODEL_ROOT=/opt/intel/computer_vision_sdk/deployment_tools/intel_models\n",
+    "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64/\n",
+    "MODEL_ROOT=models/Security/object_detection/crossroad/0078/dldt\n",
     "source scripts/setupenv.sh && ./smart_city_tutorial -i data/$VIDEO_INPUT \\\n",
-    "-m_vp $MODEL_ROOT/person-vehicle-bike-detection-crossroad-0078/$FP_MODEL/person-vehicle-bike-detection-crossroad-0078.xml \\\n",
+    "-m_vp $MODEL_ROOT/person-vehicle-bike-detection-crossroad-0078${FPEXT}.xml \\\n",
     "-d_vp $DEVICE -tracking -collision -o $OUTPUT_PATH -no_show"
    ]
   },
@@ -286,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One bigadvantage of the Job queue system is that you may submit multiple jobs at once. \n",
+    "One big advantage of the Job queue system is that you may submit multiple jobs at once. \n",
     "These jobs will be run as soon as resources are available, and may all run at once if the cluster is not busy.\n",
     "Here are few other \"preset\" jobs that for your convenience that you can run. "
    ]
@@ -333,42 +386,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#print(\"Submitting job to node with Intel FPGA HDDL-F...\")\n",
+    "print(\"Submitting job to node with Intel FPGA HDDL-F...\")\n",
     "#Submit job to the queue\n",
-    "#job_id_fpga = !qsub smart_city_demo.sh -l nodes=1:tank-870:i5-6500te:iei-mustang-f100-a10 -F \"HETERO:FPGA,CPU FP32 $VIDEO_INPUT results/\"\n",
-    "#print(job_id_fpga[0])\n",
+    "job_id_fpga = !qsub smart_city_demo.sh -l nodes=1:tank-870:i5-6500te:iei-mustang-f100-a10 -F \"HETERO:FPGA,CPU FP32 $VIDEO_INPUT results/\"\n",
+    "print(job_id_fpga[0])\n",
     "\n",
     "#Progress indicators\n",
-    "#if job_id_fpga:\n",
-    "#    progressIndicator('results/', 'i_progress_'+job_id_fpga[0]+'.txt', \"Inference\", 0, 100)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Submitting to an edge compute node with Intel® Movidius™ Neural Compute Stick\n",
-    "In the cell below, we submit a job to an <a \n",
-    "    href=\"https://software.intel.com/en-us/iot/hardware/iei-tank-dev-kit-core\">IEI \n",
-    "    Tank 870-Q170</a> edge node with an <a href=\"https://ark.intel.com/products/88186/Intel-Core-i5-6500TE-Processor-6M-Cache-up-to-3-30-GHz-\">Intel Core i5-6500te CPU</a>. The inference workload will run on an <a \n",
-    "    href=\"https://software.intel.com/en-us/movidius-ncs\">Intel \n",
-    "    Movidius Neural Compute Stick</a> installed in this node."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Submitting job to node with Intel Movidius NCS...\")\n",
-    "#Submit job to the queue\n",
-    "job_id_ncs = !qsub smart_city_demo.sh -l nodes=1:tank-870:i5-6500te:intel-ncs -F \"MYRIAD FP16 $VIDEO_INPUT results/\"\n",
-    "print(job_id_ncs[0])\n",
-    "\n",
-    "#Progress indicators\n",
-    "if job_id_ncs:\n",
-    "    progressIndicator('results/', 'i_progress_'+job_id_ncs[0]+'.txt', \"Inference\", 0, 100)"
+    "if job_id_fpga:\n",
+    "    progressIndicator('results/', 'i_progress_'+job_id_fpga[0]+'.txt', \"Inference\", 0, 100)"
    ]
   },
   {
@@ -379,7 +404,7 @@
     "In the cell below, we submit a job to an <a \n",
     "    href=\"https://software.intel.com/en-us/iot/hardware/iei-tank-dev-kit-core\">IEI \n",
     "    Tank 870-Q170</a> edge node with an <a href=\"https://ark.intel.com/products/88186/Intel-Core-i5-6500TE-Processor-6M-Cache-up-to-3-30-GHz-\">Intel Core i5-6500te CPU</a>. The inference workload will run on an <a \n",
-    "    href=\"https://software.intel.com/en-us/neural-compute-stick\">Intel Neural Compute Stick 2</a> installed in this  node."
+    "    href=\"https://software.intel.com/en-us/neural-compute-stick\">Intel Neural Compute Stick 2</a> installed in this node."
    ]
   },
   {
@@ -441,12 +466,12 @@
    "outputs": [],
    "source": [
     "#Submit job to the queue\n",
-    "#job_id_up2 = !qsub smart_city_atom.sh -l nodes=1:up-squared -F \"GPU FP32 $VIDEO_INPUT results/\"\n",
-    "#print(job_id_up2[0])\n",
+    "job_id_up2 = !qsub smart_city_demo.sh -l nodes=1:up-squared -F \"GPU FP32 $VIDEO_INPUT results/\"\n",
+    "print(job_id_up2[0])\n",
     "\n",
     "#Progress indicators\n",
-    "#if job_id_up2:\n",
-    "#    progressIndicator('results/', 'i_progress_'+job_id_up2[0]+'.txt', \"Inference\", 0, 100)"
+    "if job_id_up2:\n",
+    "    progressIndicator('results/', 'i_progress_'+job_id_up2[0]+'.txt', \"Inference\", 0, 100)"
    ]
   },
   {
@@ -517,9 +542,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#videoHTML('IEI Tank + IEI Mustang-F100-A10 (Intel® Arria® 10 FPGA)',\n",
-    "#          ['results/output_'+job_id_fpga[0]+'.mp4'],\n",
-    "#          'results/stats_'+job_id_fpga[0]+'.txt')"
+    "videoHTML('IEI Tank + IEI Mustang-F100-A10 (Intel® Arria® 10 FPGA)',\n",
+    "          ['results/output_'+job_id_fpga[0]+'.mp4'],\n",
+    "          'results/stats_'+job_id_fpga[0]+'.txt')"
    ]
   },
   {
@@ -561,9 +586,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#videoHTML('UP Squared Grove IoT Development Kit (UP2)',\n",
-    "#          ['results/output_'+job_id_up2[0]+'.mp4'],\n",
-    "#          'results/stats_'+job_id_up2[0]+'.txt')"
+    "videoHTML('UP Squared Grove IoT Development Kit (UP2)',\n",
+    "          ['results/output_'+job_id_up2[0]+'.mp4'],\n",
+    "          'results/stats_'+job_id_up2[0]+'.txt')"
    ]
   },
   {
@@ -575,11 +600,10 @@
     "arch_list = [('core', 'Intel Core\\ni5-6500TE\\nCPU'),\n",
     "             ('xeon', 'Intel Xeon\\nE3-1268L v5\\nCPU'),\n",
     "             ('gpu', ' Intel Core\\ni5-6500TE\\nGPU'),\n",
-    "      #       ('fpga', ' IEI Mustang\\nF100-A10\\nFPGA'),\n",
-    "             ('ncs', 'Intel\\nMovidius\\nNCS'),\n",
+    "             ('fpga', ' IEI Mustang\\nF100-A10\\nFPGA'),\n",
     "             ('ncs2', 'Intel\\nNCS2'),\n",
-    "             ('vpu', ' IEI Mustang\\nV100-MX8\\nVPU')]\n",
-    "      #      ('up2', 'Intel Atom\\nx7-E3950\\nUP2/GPU')]\n",
+    "             ('vpu', ' IEI Mustang\\nV100-MX8\\nVPU'),\n",
+    "             ('up2', 'Intel Atom\\nx7-E3950\\nUP2/GPU')]\n",
     "\n",
     "stats_list = []\n",
     "for arch, a_name in arch_list:\n",

--- a/demoTools/demoutils.py
+++ b/demoTools/demoutils.py
@@ -10,7 +10,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import os 
 import warnings
-import xml.etree.ElementTree as ET
 
 def videoHTML(title, videos_list, stats=None):
     '''
@@ -113,22 +112,6 @@ def liveQstat():
     sb.on_click(_stop_qstat)
     display(qstat)
     display(sb)
-
-def qjobWait(id_list, timeout=-1):
-  start_time = time.time()
-  while True:
-    time.sleep(0.5)
-    cmd = ['qstat', '-x']
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    output,_ = p.communicate()
-    qstat_out = ET.fromstring(output.decode())
-    if not any([i.find('Job_Id').text in id_list for i in qstat_out]):
-      print('Jobs are completed')
-      break
-    if timeout > 0 and int(time.time()-start_time) > timeout:
-      print('Timeout reached. Exiting')
-      break
-
 
    
 def progressIndicator(path, file_name , title, min_, max_):


### PR DESCRIPTION
Adapt smartcity-near-misses example for openvino 2019 R1.
Also disable AVX2 for running the program on every node. Revert commits by @rasai as we no longer need to compile on the nodes.