### PR TITLE
removed unnecessary cell in live traffic demo

### DIFF
--- a/python/live-traffic-example/live_traffic_detection_demo.ipynb
+++ b/python/live-traffic-example/live_traffic_detection_demo.ipynb
@@ -331,17 +331,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "videoHTML('IEI Tank Xeon (Intel Xeon CPU)',\n",
-    "          ['results/output_'+job_id_xeon[0]+'.mp4'],\n",
-    "          'results/stats_'+job_id_xeon[0]+'.txt')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
there was a videohtml after xeon job submission:
![image](https://user-images.githubusercontent.com/35304450/61174803-42ed5300-a55a-11e9-865d-bf4bf8423169.png)
