### PR TITLE
fix OCR example build_samples.sh path

### DIFF
--- a/python/developer_samples/OCR-usingLSTM-python/OCR.ipynb
+++ b/python/developer_samples/OCR-usingLSTM-python/OCR.ipynb
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!/opt/intel/openvino/deployment_tools/inference_engine/samples/build_samples.sh"
+    "!/opt/intel/openvino/deployment_tools/inference_engine/samples/cpp/build_samples.sh"
    ]
   },
   {


### PR DESCRIPTION
The "OCR (Optical Character Recognition)" Sample Application in python/developer_samples needs the following fix:
In "2. Inference Engine"
In "Compile the CPU extension lib:"
`!/opt/intel/openvino/deployment_tools/inference_engine/samples/build_samples.sh`
Needs to be updated to:
`!/opt/intel/openvino/deployment_tools/inference_engine/samples/cpp/build_samples.sh`

Fixed in this pull request.